### PR TITLE
style: streamline run tracker ads

### DIFF
--- a/work/run/index.html
+++ b/work/run/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=360, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-  <title>태어난 날로 보는 조선시대 나의 이름(Feat. 노비)</title>
-  <meta name="description" content="태어난 날로 알아보는 조선시대 나의 이름 찾기">
-  <meta name="keywords" content="조선시대 이름, 노비 이름 테스트, 서바이벌오피스, 조선시대 심리테스트, 조선, 노비, 심리테스트, 테스트, 미니게임, ">
+  <title>러닝 리포트 메이커</title>
+  <meta name="description" content="러닝 기록을 직접 입력하고 효과를 선택해 영상 캡처에 활용하세요.">
+  <meta name="keywords" content="러닝, 운동 기록, 러닝 리포트, 페이스, 케이던스, 러닝 캡쳐">
 
   <!-- Google Adsense -->
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4957586937754537" crossorigin="anonymous"></script>
@@ -21,21 +21,14 @@
   </script>
 
   <!-- Open Graph -->
-  <meta property="og:title" content="태어난 날로 보는 조선시대 나의 이름(Feat. 노비)" />
-  <meta property="og:description" content="태어난 날로 알아보는 조선시대 나의 이름 찾기" />
-  <meta property="og:url" content="https://www.survivaloffice.com/test/slave" />
-  <meta property="og:image" content="https://www.survivaloffice.com/images/slave1.png" />
+  <meta property="og:title" content="러닝 리포트 메이커" />
+  <meta property="og:description" content="직접 입력한 러닝 기록을 감각적인 효과와 함께 캡쳐해 보세요." />
+  <meta property="og:url" content="https://www.survivaloffice.com/work/run" />
+  <meta property="og:image" content="https://www.survivaloffice.com/images/run-thumb.png" />
   <meta property="og:type" content="website" />
-
-  <link rel="preconnect" href="https://api.counterapi.dev" crossorigin>
-  <link rel="dns-prefetch" href="https://api.counterapi.dev">
-
-  <!-- Kakao SDK -->
-  <script src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.2/kakao.min.js" crossorigin="anonymous"></script>
 
   <link rel="stylesheet" href="style.css">
 </head>
-
 <body oncontextmenu="return false">
   <nav>
     <ul>
@@ -47,7 +40,7 @@
   </nav>
 
   <!-- 상단 광고 -->
-  <div class="ad-container">
+  <div class="ad-container" aria-label="상단 광고 영역">
     <ins class="adsbygoogle"
          style="display:block; min-height: 90px;"
          data-ad-client="ca-pub-4957586937754537"
@@ -56,93 +49,98 @@
          data-full-width-responsive="true"></ins>
   </div>
 
-  <main id="app" role="main">
-    <!-- 시작화면 -->
-    <section id="start-screen" class="screen active" aria-labelledby="start-title"
-      style="background:url('https://www.survivaloffice.com/images/slavemain.png') center/cover no-repeat;">
-      <div class="screen-overlay start-overlay">
-        <h1 id="start-title">태어난 날로 보는<br>조선시대 나의 이름<br>(Feat. 노비)</h1>
-        <button id="start-btn" class="primary-btn start-cta" type="button">이름 찾기</button>
-      </div>
-    </section>
-
-      <!-- 참여자 수 배지 -->
-      <div id="test-counter"
-           class="counter-badge"
-           data-counter-namespace="survivaloffice"
-           data-counter-key="slave">
-        총 0명 참여
-      </div>
-
-    <!-- 스토리 -->
-    <section id="story-screen" class="screen" aria-live="polite">
-      <div class="story-wrapper">
-        <p id="story-text" class="story-text" aria-live="polite"></p>
-      </div>
-      <div class="bottom-cta">
-        <button id="story-next" class="primary-btn" type="button" hidden>계속하기</button>
-      </div>
-    </section>
-
-    <!-- 성별 선택 -->
-    <section id="gender-screen" class="screen" aria-labelledby="gender-title">
-      <h2 id="gender-title">성별을 선택하세요</h2>
-      <p class="gender-helper">조선시대 남녀는 이름짓는 풍습도 달랐답니다.</p>
-      <div class="gender-grid" role="list">
-        <button class="gender-card" type="button" data-gender="male" role="listitem"
-          style="background:url('https://www.survivaloffice.com/images/slavem.png') center/cover no-repeat;">
-          <span class="gender-label">남성</span>
-        </button>
-        <button class="gender-card" type="button" data-gender="female" role="listitem"
-          style="background:url('https://www.survivaloffice.com/images/slavef.png') center/cover no-repeat;">
-          <span class="gender-label">여성</span>
-        </button>
-      </div>
-    </section>
-
-    <!-- 생월/생일 입력 -->
-    <section id="birth-screen" class="screen" aria-labelledby="birth-title">
-      <h2 id="birth-title">태어난 월과 일자를 입력하세요</h2>
-      <form id="birth-form" novalidate>
-        <div class="form-field">
-          <label for="birth-month">태어난 달</label>
-          <input id="birth-month" name="birth-month" type="number" inputmode="numeric" min="1" max="12" placeholder="예: 6" required>
+  <main class="run-lab" role="main" aria-labelledby="app-title">
+    <div class="app-shell" aria-live="polite">
+      <header class="control-panel">
+        <div class="panel-head">
+          <p id="app-title">러닝 리포트 메이커</p>
+          <p class="panel-desc">숫자를 입력하고 원하는 효과를 고르면 촬영-ready!</p>
         </div>
-        <div class="form-field">
-          <label for="birth-day">태어난 날</label>
-          <input id="birth-day" name="birth-day" type="number" inputmode="numeric" min="1" max="31" placeholder="예: 17" required>
+        <div class="panel-grid">
+          <label class="panel-field" for="effectSelect">
+            <span>효과</span>
+            <select id="effectSelect">
+              <option value="smooth">천천히 상승</option>
+              <option value="bounce">탄성 상승</option>
+              <option value="snap">스냅 점프</option>
+            </select>
+          </label>
+          <label class="panel-field" for="textColor">
+            <span>글자색</span>
+            <input type="color" id="textColor" value="#111111" aria-label="글자색 선택">
+          </label>
+          <label class="panel-field" for="accentColor">
+            <span>포인트</span>
+            <input type="color" id="accentColor" value="#ff3b58" aria-label="포인트 색상 선택">
+          </label>
         </div>
-        <p id="birth-error" class="error-text" role="alert" aria-live="assertive"></p>
-        <button id="reveal-btn" class="primary-btn" type="submit">이름 찾기</button>
-      </form>
-    </section>
+        <div class="panel-toggles">
+          <label class="toggle">
+            <input type="checkbox" id="slowMode" checked>
+            <span>느리게 차오르기</span>
+          </label>
+          <label class="toggle">
+            <input type="checkbox" id="glowEffect">
+            <span>하이라이트 글로우</span>
+          </label>
+        </div>
+      </header>
 
-    <!-- 로딩 -->
-    <section id="loading-screen" class="screen" aria-live="polite">
-      <div class="loading-wrapper">
-        <div class="loader" role="status" aria-label="이름 생성 중"></div>
-        <p class="loading-text">조선의 호적에서 이름을 찾고 있습니다...</p>
-      </div>
-    </section>
+      <section class="record-card" aria-label="러닝 기록 카드">
+        <div class="distance-section">
+          <p class="metric-label">킬로미터</p>
+          <div class="distance-display" data-display-group>
+            <span id="kmDisplay" class="distance-number">0.00</span>
+            <span class="unit">km</span>
+          </div>
+          <input type="number" inputmode="decimal" step="0.01" id="kmInput" placeholder="0.00" aria-label="킬로미터 입력">
+        </div>
 
-    <!-- 결과 -->
-    <section id="result-screen" class="screen" aria-labelledby="result-title">
-      <div class="result-wrapper">
-        <h2 id="result-title">당신의 조선시대 이름은</h2>
-        <p id="result-name" class="result-name"></p>
-        <p id="result-desc" class="result-desc"></p>
+        <div class="metrics-grid">
+          <article class="metric" data-type="time">
+            <p class="metric-label">페이스</p>
+            <p id="paceDisplay" class="metric-value">--:--</p>
+            <input id="paceInput" type="text" inputmode="numeric" placeholder="08:25" aria-label="페이스 입력 (분:초)">
+          </article>
+          <article class="metric" data-type="time">
+            <p class="metric-label">시간</p>
+            <p id="timeDisplay" class="metric-value">00:00</p>
+            <input id="timeInput" type="text" inputmode="numeric" placeholder="05:00" aria-label="시간 입력 (분:초)">
+          </article>
+          <article class="metric" data-type="number" data-decimals="0">
+            <p class="metric-label">칼로리</p>
+            <p id="calDisplay" class="metric-value">0</p>
+            <input id="calInput" type="number" inputmode="numeric" placeholder="37" aria-label="칼로리 입력">
+          </article>
+          <article class="metric" data-type="number" data-decimals="0">
+            <p class="metric-label">고도 상승</p>
+            <p id="elevDisplay" class="metric-value">0 m</p>
+            <input id="elevInput" type="number" inputmode="numeric" placeholder="3" aria-label="고도 상승 입력">
+          </article>
+          <article class="metric" data-type="number" data-decimals="0">
+            <p class="metric-label">평균 심박</p>
+            <p id="heartDisplay" class="metric-value">-- bpm</p>
+            <input id="heartInput" type="number" inputmode="numeric" placeholder="131" aria-label="평균 심박수 입력">
+          </article>
+          <article class="metric" data-type="number" data-decimals="0">
+            <p class="metric-label">케이던스</p>
+            <p id="cadenceDisplay" class="metric-value">0 spm</p>
+            <input id="cadenceInput" type="number" inputmode="numeric" placeholder="168" aria-label="케이던스 입력">
+          </article>
+        </div>
+      </section>
+
+      <div class="action-row">
+        <button id="recordBtn" class="primary-btn" type="button">효과 적용 &amp; 기록</button>
+        <button id="resetBtn" class="ghost-btn" type="button">초기화</button>
       </div>
 
-      <div id="bottom-actions" style="display: none;">
-        <button id="share-kakao">공유하기</button>
-        <button id="restart-btn">다시하기</button>
-        <button id="other-test-btn" onclick="location.href='https://survivaloffice.com/test'">다른 테스트 하기</button>
-      </div>
-    </section>
+      <p class="helper-text">TIP. 값 입력 → 효과 선택 → 전체 화면 캡쳐로 러닝 하이라이트를 남겨보세요.</p>
+    </div>
   </main>
 
   <!-- 하단 광고 -->
-  <div class="footer-ad-container">
+  <div class="footer-ad-container" aria-label="하단 광고 영역">
     <ins class="adsbygoogle" style="display:block"
          data-ad-client="ca-pub-4957586937754537"
          data-ad-slot="9931828353"
@@ -150,7 +148,20 @@
          data-full-width-responsive="true"></ins>
   </div>
 
-  <p class="sr-only">쿠팡 광고</p>
+  <section class="coupang-slot" aria-label="쿠팡 광고">
+    <p class="sr-only">쿠팡 제휴 광고</p>
+    <script src="https://ads-partners.coupang.com/g.js"></script>
+    <script>
+      new PartnersCoupang.G({
+        id: 810614,
+        trackingCode: "AF4453761",
+        subId: null,
+        template: "carousel",
+        width: "360",
+        height: "100"
+      });
+    </script>
+  </section>
 
   <script type="module" src="script.js"></script>
   <script>
@@ -165,9 +176,5 @@
     });
   </script>
 
-  <script src="https://ads-partners.coupang.com/g.js"></script>
-  <script>
-    new PartnersCoupang.G({ id: 810614, trackingCode: "AF4453761", subId: null, template: "carousel", width: "360", height: "100" });
-  </script>
 </body>
 </html>

--- a/work/run/script.js
+++ b/work/run/script.js
@@ -1,290 +1,159 @@
-document.addEventListener("DOMContentLoaded", () => {
-  console.log("✅ 조선시대 이름 테스트 로드 완료");
+document.addEventListener('DOMContentLoaded', () => {
+  const card = document.querySelector('.record-card');
+  const effectSelect = document.getElementById('effectSelect');
+  const slowMode = document.getElementById('slowMode');
+  const glowEffect = document.getElementById('glowEffect');
+  const textColor = document.getElementById('textColor');
+  const accentColor = document.getElementById('accentColor');
+  const recordBtn = document.getElementById('recordBtn');
+  const resetBtn = document.getElementById('resetBtn');
+  const kmInput = document.getElementById('kmInput');
+  const kmDisplay = document.getElementById('kmDisplay');
 
-  // --- 화면 요소 ---
-  const screens = {
-    start: document.getElementById("start-screen"),
-    story: document.getElementById("story-screen"),
-    gender: document.getElementById("gender-screen"),
-    birth: document.getElementById("birth-screen"),
-    loading: document.getElementById("loading-screen"),
-    result: document.getElementById("result-screen"),
-  };
-
-  const startBtn   = document.getElementById("start-btn");
-  const storyText  = document.getElementById("story-text");
-  const storyNext  = document.getElementById("story-next");
-  const genderBtns = document.querySelectorAll(".gender-card");
-  const revealBtn  = document.getElementById("reveal-btn");
-  const restartBtn = document.getElementById("restart-btn");
-  const shareBtn   = document.getElementById("share-kakao");
-  const bottomActions = document.getElementById("bottom-actions");
-
-  const birthMonth = document.getElementById("birth-month");
-  const birthDay   = document.getElementById("birth-day");
-  const birthError = document.getElementById("birth-error");
-
-  const resultName = document.getElementById("result-name");
-  const resultDesc = document.getElementById("result-desc");
-
-  let state = { gender: null, month: null, day: null };
-
-  // --- 이름 데이터 ---
-  const maleNames = [
-    "돌쇠","칠복","만석","복길","용식","철수","갑돌","상팔","칠수","춘복",
-    "봉구","말돌","칠돌","상득","복남","학수","득복","칠성","용태","칠구"
+  const metrics = [
+    { input: document.getElementById('paceInput'), display: document.getElementById('paceDisplay'), type: 'time', fallback: '--:--' },
+    { input: document.getElementById('timeInput'), display: document.getElementById('timeDisplay'), type: 'time', fallback: '00:00' },
+    { input: document.getElementById('calInput'), display: document.getElementById('calDisplay'), type: 'number', decimals: 0, suffix: '', fallback: '0' },
+    { input: document.getElementById('elevInput'), display: document.getElementById('elevDisplay'), type: 'number', decimals: 0, suffix: ' m', fallback: '0 m' },
+    { input: document.getElementById('heartInput'), display: document.getElementById('heartDisplay'), type: 'number', decimals: 0, suffix: ' bpm', fallback: '-- bpm' },
+    { input: document.getElementById('cadenceInput'), display: document.getElementById('cadenceDisplay'), type: 'number', decimals: 0, suffix: ' spm', fallback: '0 spm' }
   ];
 
-  const femaleNames = [
-    "꽃분","춘심","봉순","덕순","분이","옥녀","순덕","미향","정순","복녀",
-    "영심","분례","향단","난순","옥분","금향","영숙","복순","향이","금이"
-  ];
-
-  // --- 결과 설명 ---
-  const maleDescriptions = [
-    "는 농사에 능해 사람들의 든든한 버팀목이 되었다고 합니다.",
-    "는 말수가 적지만 일솜씨가 뛰어나 마을의 신뢰를 얻었다고 합니다.",
-    "는 힘이 세고 성격이 호탕해 장정들 사이에서 인기가 많았다고 합니다.",
-    "는 주인댁의 일을 묵묵히 해내 늘 인정받았다고 합니다.",
-    "는 일을 마치고도 이웃의 일을 거들어주는 인심 좋은 인물이었다고 합니다.",
-    "는 낮에는 밭일, 밤에는 나무를 해오며 가족을 지켰다고 합니다.",
-    "는 마을의 장정을 대표해 큰 행사를 도왔다는 기록이 남아 있습니다.",
-    "는 젊을 적부터 성실해 주막집에서도 신용이 좋았다고 합니다.",
-    "는 말보단 행동으로 믿음을 쌓은 사람이었다고 합니다.",
-    "는 남의 일도 자기 일처럼 챙기는 성품으로 유명했습니다.",
-    "는 어려운 상황에서도 웃음을 잃지 않았다고 합니다.",
-    "는 농한기마다 장터에서 품을 팔며 집안을 일으켰다고 합니다.",
-    "는 허리춤에 낫을 차고 새벽마다 들판을 누볐다고 합니다.",
-    "는 벼를 베는 솜씨가 좋아 장원급 농사꾼으로 불렸다고 합니다.",
-    "는 어릴 적부터 우직하다는 말을 자주 들었다고 합니다.",
-    "는 성격이 곧고 정의로워 다툼을 말리는 역할을 했다고 합니다.",
-    "는 겨울에도 맨손으로 물길을 트던 근면한 인물이었습니다.",
-    "는 이웃과 정을 나누며 살던 정 많은 사람이었다고 합니다.",
-    "는 품삯보다 신의를 먼저 챙겼다고 전해집니다.",
-    "는 하늘이 내린 일꾼이라 불릴 만큼 성실했다고 합니다."
-  ];
-
-  const femaleDescriptions = [
-    "는 살림이 야무지고 손재주가 좋아 동네 사람들이 자주 찾았다고 합니다.",
-    "는 마음씨가 곱고 노래를 잘 불러 장터의 인기인이었다고 합니다.",
-    "는 새벽마다 물을 길어와 주인댁의 우물을 채웠다고 합니다.",
-    "는 부지런하고 어질어 노모를 잘 모셨다고 합니다.",
-    "는 바느질 솜씨가 좋아 근처 고을에서도 주문이 끊이지 않았다고 합니다.",
-    "는 웃음소리가 예뻐 마을의 활력소가 되었다고 합니다.",
-    "는 이웃의 아이들을 돌보며 모두의 누이로 불렸다고 합니다.",
-    "는 사계절 내내 바느질로 가족을 먹여 살렸다고 합니다.",
-    "는 명절마다 떡을 빚어 나눠주던 인심 좋은 여인이었다고 합니다.",
-    "는 어릴 적부터 말수가 적고 마음이 깊었다고 합니다.",
-    "는 눈이 맑고 손끝이 섬세해 옷감에 생명을 불어넣었다고 합니다.",
-    "는 약초를 다뤄 마을 사람들의 병을 자주 고쳐줬다고 합니다.",
-    "는 소문난 손맛으로 주막집의 간판 요리사가 되었다고 합니다.",
-    "는 장날마다 어깨에 보자기를 메고 웃으며 장터를 누볐다고 합니다.",
-    "는 새벽마다 장작을 패던 어여쁜 기개로 유명했습니다.",
-    "는 낯선 이에게도 따뜻하게 대해줬다고 합니다.",
-    "는 꾸밈없는 성격으로 많은 이들의 신뢰를 얻었다고 합니다.",
-    "는 어두운 밤에도 등불을 들고 사람을 맞이했다고 합니다.",
-    "는 고운 마음씨 덕분에 아이들에게 존경받았다고 합니다.",
-    "는 주인댁에서도 인정받은 성실한 여인이었다고 합니다."
-  ];
-
-  // --- 공용 함수 ---
-  function showScreen(target) {
-    Object.values(screens).forEach(s => s.classList.remove("active"));
-    target.classList.add("active");
-    bottomActions.style.display = target === screens.result ? "flex" : "none";
-
-    // ✅ 추가: 참여자 수 배지 제어
-    const counterBadge = document.getElementById("test-counter");
-    if (counterBadge) {
-      // 시작화면에서만 표시, 그 외 화면에서는 숨김
-      counterBadge.style.display = target === screens.start ? "block" : "none";
-    }
-  }
-
-  function pick(arr) {
-    return arr[Math.floor(Math.random() * arr.length)];
-  }
-
-  function getName(gender, month, day) {
-    const list = gender === "female" ? femaleNames : maleNames;
-    return list[(month * 31 + day) % list.length];
-  }
-
-  function getDescription(gender) {
-    return gender === "female" ? pick(femaleDescriptions) : pick(maleDescriptions);
-  }
-
-  function validateBirth(month, day) {
-    if (!month || !day || month < 1 || month > 12 || day < 1 || day > 31) {
-      birthError.textContent = "올바른 월과 일을 입력해주세요.";
-      return false;
-    }
-    birthError.textContent = "";
-    return true;
-  }
-
-  // --- 한글 받침 판별 & '이' 자동 처리 ---
-  function hasBatchim(korChar) {
-    const code = korChar.charCodeAt(0) - 0xac00;
-    if (code < 0 || code > 11171) return false;
-    return code % 28 !== 0; // 종성이 있으면 true
-  }
-  function formatNameWithParticle(name) {
-    if (!name || typeof name !== "string") return name;
-    const last = name.charAt(name.length - 1);
-    return hasBatchim(last) ? `${name}이` : name;
-  }
-
-  // --- 결과 표시 ---
-  function showResult() {
-    const rawName  = getName(state.gender, state.month, state.day) || "이름미상";
-    const desc     = getDescription(state.gender);
-    const finalName = formatNameWithParticle(rawName); // ← 여기!
-
-    resultName.textContent = finalName;                // 제목에도 '이' 반영
-    resultDesc.textContent = `${finalName}${desc}`;    // 설명도 자연스럽게
-    showScreen(screens.result);
-  }
-
-  // --- 스토리 타자효과 ---
-  function typeStory(text, callback) {
-    storyText.textContent = "";
-    storyNext.hidden = true;
-    let i = 0;
-    const timer = setInterval(() => {
-      storyText.textContent += text[i];
-      i++;
-      if (i >= text.length) {
-        clearInterval(timer);
-        storyNext.hidden = false;
-        storyNext.onclick = callback;
-      }
-    }, 45);
-  }
-
-  // --- 실행 흐름 ---
-  startBtn.onclick = () => {
-    showScreen(screens.story);
-    typeStory(
-      "조선시대, 당신은 양반이 아닌 노비로 태어났습니다.\n\n삶은 고되고 자유는 없었지만, 그래도 하늘 아래 모두 사람이라 믿으며 하루하루를 살아갔죠.\n주인댁의 심부름부터 밭일, 물지게까지… 당신의 손은 언제나 바쁘게 움직였습니다.\n그 시절, 사람들은 이름에 마음을 담았으니까요.\n\n이제 조선시대에 태어난 당신의 이름을 찾아보겠습니다.",
-      () => showScreen(screens.gender)
-    );
-  };
-
-  genderBtns.forEach(btn => {
-    btn.onclick = () => {
-      // 선택 강조
-      genderBtns.forEach(b => b.classList.remove("selected"));
-      btn.classList.add("selected");
-
-      state.gender = btn.dataset.gender;
-      showScreen(screens.birth);
-    };
-  });
-
-  revealBtn.onclick = e => {
-    e.preventDefault();
-    const month = parseInt(birthMonth.value, 10);
-    const day   = parseInt(birthDay.value, 10);
-    if (!validateBirth(month, day)) return;
-    state.month = month;
-    state.day   = day;
-    showScreen(screens.loading);
-    setTimeout(showResult, 5000);
-  };
-
-  restartBtn.onclick = () => {
-    birthMonth.value = "";
-    birthDay.value = "";
-    // 리셋 시 선택 강조 제거
-    genderBtns.forEach(b => b.classList.remove("selected"));
-    showScreen(screens.start);
-  };
-
-// --- 카카오 공유 ---
-function loadKakao() {
-  const s = document.createElement("script");
-  s.src = "https://developers.kakao.com/sdk/js/kakao.min.js";
-  s.onload = () => {
-    try { Kakao.init("eee6c2e01641161de9f217ba99c6a0da"); }
-    catch (e) { console.warn("Kakao init 실패:", e); }
-  };
-  document.head.appendChild(s);
-}
-loadKakao();
-
-// 👇 성별에 따른 공유 이미지 선택 함수
-function getShareImage(gender) {
-  if (gender === "male") return "https://www.survivaloffice.com/images/slavem.png";
-  if (gender === "female") return "https://www.survivaloffice.com/images/slavef.png";
-  return "https://www.survivaloffice.com/images/slave1.png"; // fallback
-}
-
-// --- 카카오 공유 버튼 ---
-shareBtn.onclick = () => {
-  if (!window.Kakao || !Kakao.isInitialized()) {
-    alert("⚠️ 카카오톡 공유 기능을 사용할 수 없습니다.");
-    return;
-  }
-
-  const shownName = resultName.textContent || "이름 미상";   // 최종 이름
-  const descText  = resultDesc.textContent || "";             // 결과 설명
-  const imageUrl  = getShareImage(state.gender);              // 성별별 이미지 선택
-
-  Kakao.Link.sendDefault({
-    objectType: "feed",
-    content: {
-      title: `나의 조선시대 이름은 ${shownName}!`, // ✅ 이름이 제목에 포함됨
-      description: descText,                        // ✅ 결과 설명도 함께 표시
-      imageUrl: imageUrl,
-      imageWidth: 600,
-      imageHeight: 600,
-      link: { mobileWebUrl: location.href, webUrl: location.href },
+  const easing = {
+    smooth: t => t,
+    bounce: t => {
+      const n1 = 7.5625;
+      const d1 = 2.75;
+      if (t < 1 / d1) return n1 * t * t;
+      if (t < 2 / d1) return n1 * (t -= 1.5 / d1) * t + 0.75;
+      if (t < 2.5 / d1) return n1 * (t -= 2.25 / d1) * t + 0.9375;
+      return n1 * (t -= 2.625 / d1) * t + 0.984375;
     },
-    buttons: [
-      { 
-        title: "나도 테스트 해보기", 
-        link: { mobileWebUrl: location.href, webUrl: location.href } 
+    snap: t => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2)
+  };
+
+  function parseTimeValue(value) {
+    if (!value) return null;
+    const numeric = value.replace(/[^0-9]/g, '');
+    if (!numeric) return null;
+    const padded = numeric.padStart(2, '0');
+    const minutes = parseInt(padded.slice(0, -2) || '0', 10);
+    const seconds = parseInt(padded.slice(-2), 10);
+    return minutes * 60 + seconds;
+  }
+
+  function formatTime(totalSeconds) {
+    const minutes = Math.floor(totalSeconds / 60).toString().padStart(2, '0');
+    const seconds = Math.floor(totalSeconds % 60).toString().padStart(2, '0');
+    return `${minutes}:${seconds}`;
+  }
+
+  function animateNumber(el, target, { duration = 1500, decimals = 0, suffix = '' } = {}) {
+    const start = performance.now();
+    const ease = easing[effectSelect.value] || easing.smooth;
+
+    function frame(now) {
+      const progress = Math.min((now - start) / duration, 1);
+      const eased = ease(progress);
+      const current = target * eased;
+      el.textContent = `${current.toFixed(decimals)}${suffix}`;
+      if (progress < 1) {
+        requestAnimationFrame(frame);
       }
-    ],
-  });
-};
+    }
 
-  // --- 참여 카운터 ---
-  const COUNTER_BASE = "https://api.counterapi.dev/v1";
-  async function fetchCount(ns, key) {
-    try {
-      const r = await fetch(`${COUNTER_BASE}/${ns}/${key}/`, { cache: "no-store" });
-      const d = await r.json();
-      return d.count || d.value || 0;
-    } catch {
-      return 0;
-    }
-  }
-  async function hitCount(ns, key) {
-    try {
-      const r = await fetch(`${COUNTER_BASE}/${ns}/${key}/up`, { cache: "no-store" });
-      const d = await r.json();
-      return d.count || d.value || null;
-    } catch {
-      return null;
-    }
-  }
-  function renderCount(el, n) {
-    if (!el) return;
-    el.textContent = `총 ${Number(n).toLocaleString()}명 참여`;
+    requestAnimationFrame(frame);
   }
 
-  (async function initCounter() {
-    const el = document.getElementById("test-counter");
-    if (!el) return;
-    const ns = el.dataset.counterNamespace || "survivaloffice";
-    const key = el.dataset.counterKey || "NobiName";
-    const val = await fetchCount(ns, key);
-    renderCount(el, val);
-    startBtn.addEventListener("click", async () => {
-      const after = await hitCount(ns, key);
-      if (after !== null) renderCount(el, after);
+  function animateTime(el, seconds, duration) {
+    const start = performance.now();
+    const ease = easing[effectSelect.value] || easing.smooth;
+
+    function frame(now) {
+      const progress = Math.min((now - start) / duration, 1);
+      const eased = ease(progress);
+      const current = seconds * eased;
+      el.textContent = formatTime(current);
+      if (progress < 1) {
+        requestAnimationFrame(frame);
+      }
+    }
+
+    requestAnimationFrame(frame);
+  }
+
+  function updateColors() {
+    document.documentElement.style.setProperty('--text-color', textColor.value);
+    document.documentElement.style.setProperty('--accent-color', accentColor.value);
+  }
+
+  function resetDisplays() {
+    kmDisplay.textContent = '0.00';
+    metrics.forEach(metric => {
+      metric.display.textContent = metric.fallback || '0';
     });
-  })();
+  }
+
+  function applyEffect(replay = false) {
+    if (replay) {
+      card.removeAttribute('data-effect');
+      // force reflow so CSS animations restart
+      void card.offsetWidth;
+    }
+    card.dataset.effect = effectSelect.value;
+    card.classList.toggle('glow', glowEffect.checked);
+  }
+
+  function handleRecord() {
+    applyEffect(true);
+    updateColors();
+    const duration = slowMode.checked ? 2200 : 1200;
+
+    const distance = parseFloat(kmInput.value);
+    if (!Number.isNaN(distance) && distance >= 0) {
+      animateNumber(kmDisplay, distance, { duration, decimals: 2 });
+    } else {
+      kmDisplay.textContent = '0.00';
+    }
+
+    metrics.forEach(metric => {
+      if (metric.type === 'time') {
+        const seconds = parseTimeValue(metric.input.value);
+        if (seconds !== null) {
+          animateTime(metric.display, seconds, duration);
+        } else {
+          metric.display.textContent = metric.fallback || '--:--';
+        }
+      } else {
+        const value = parseFloat(metric.input.value);
+        if (!Number.isNaN(value)) {
+          animateNumber(metric.display, value, {
+            duration,
+            decimals: metric.decimals || 0,
+            suffix: metric.suffix || ''
+          });
+        } else {
+          metric.display.textContent = metric.fallback || '0';
+        }
+      }
+    });
+  }
+
+  function handleReset() {
+    kmInput.value = '';
+    metrics.forEach(metric => { metric.input.value = ''; });
+    resetDisplays();
+  }
+
+  textColor.addEventListener('input', updateColors);
+  accentColor.addEventListener('input', updateColors);
+  glowEffect.addEventListener('change', applyEffect);
+  effectSelect.addEventListener('change', applyEffect);
+
+  recordBtn.addEventListener('click', handleRecord);
+  resetBtn.addEventListener('click', handleReset);
+
+  updateColors();
+  applyEffect();
+  resetDisplays();
 });

--- a/work/run/style.css
+++ b/work/run/style.css
@@ -1,224 +1,319 @@
-@font-face {
-    font-family: 'Shilla';
-    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2206-02@1.0/Shilla_CultureM-Medium.woff2') format('woff2');
-    font-weight: 500;
-    font-display: swap;
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+:root {
+  --text-color: #111111;
+  --accent-color: #ff3b58;
+  --panel: #f5f5f7;
+  --border: #ececf0;
+  --card-surface: #f8f8fb;
+  --input-surface: #f3f4f8;
+  --shadow: 0 20px 40px rgba(15, 23, 42, 0.12);
 }
 
-:root{
-  --ink:#1c1a18; --muted:#5a524d; --surface:rgba(255,255,255,0.85);
-  --accent:#b07c3a; --accent-dark:#825a22; --paper:#f5efe6; --error:#d94a38;
-  color-scheme:only light;
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Inter', 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  background: #ffffff;
+  color: var(--text-color);
+  min-height: 100vh;
 }
 
-*{margin:0; padding:0; box-sizing:border-box;}
-
-html,body{
-  min-height:100vh;
-  background:
-    radial-gradient(120% 120% at 50% -10%, rgba(94,60,23,.35) 0%, transparent 65%),
-    radial-gradient(100% 120% at 50% 100%, rgba(206,170,120,.28) 0%, transparent 70%),
-    #f4ece1;
-  font-family:'Shilla','Pretendard',-apple-system,BlinkMacSystemFont,sans-serif;
-  color:var(--ink);
-  display:flex; flex-direction:column; align-items:center;
-  overflow-x:hidden;
-}
-
-nav{position:fixed; top:0; left:0; width:100%;
-  background:rgba(244,236,225,.96); border-bottom:1px solid rgba(130,90,34,.18);
-  z-index:100; backdrop-filter:blur(8px);
-}
-nav ul{display:flex; justify-content:flex-end; list-style:none; gap:10px; padding:10px 20px;}
-nav a{text-decoration:none; color:var(--ink); font-size:14px; padding:6px 12px; border-radius:16px; transition:background .2s;}
-nav a:hover{background:rgba(176,124,58,.15);}
-
-.ad-container,.footer-ad-container{width:100%; min-height:90px; display:flex; justify-content:center; align-items:center; margin-top:70px;}
-.footer-ad-container{margin:32px 0 48px;}
-.adsbygoogle{width:100%; height:auto!important;}
-
-#app{
-  position:relative; width:360px; height:550px; margin-top:20px;
-  border-radius:28px; overflow:hidden;
-  box-shadow:0 18px 45px rgba(79,60,36,.2);
-  border:1px solid rgba(255,255,255,.6); background:var(--paper);
-}
-
-/* 참여자 배지/버튼은 항상 최상단 */
-.counter-badge,
-.start-btn-container { position: absolute; z-index: 9999; }
-
-.counter-badge{
-  top: 10px; right: 10px;
-  background: #b07c3a(184, 162, 162, 0.9);
-  color: #ffffff;
-  padding: 6px 12px;
-  border-radius: 999px;
-  font-size: 12px; font-weight: 700;
-  border: 1px solid var(--line);
-  box-shadow: 0 6px 16px rgba(0,0,0,.06);
-  backdrop-filter: blur(4px);
-  pointer-events: none;
-}
-
-/* 각 화면 공통 */
-.screen{
-  position:absolute; inset:0;
-  display:none;
-  padding:32px 24px;
-  overflow-y:auto; /* ✅ 내부 스크롤 허용 */
-  -webkit-overflow-scrolling:touch;
-}
-.screen.active {
+body {
   display: flex;
   flex-direction: column;
-  justify-content: flex-start; /* 👈 중앙 → 위쪽 */
   align-items: center;
-  text-align: center;
-  padding-top: 60px; /* 👈 여백 추가로 자연스럽게 */
 }
 
-#start-screen{background:url('https://www.survivaloffice.com/images/slave1.png') center/cover no-repeat;}
-#start-screen::before{content:""; position:absolute; inset:0;
-  background:linear-gradient(180deg,rgba(18,10,5,.65) 0%, rgba(18,10,5,.1) 60%, rgba(18,10,5,.65) 100%);
+nav {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  background: #ffffff;
+  border-bottom: 1px solid var(--border);
+  z-index: 30;
 }
 
-/* 시작화면 */
-.screen-overlay{position:relative; z-index:1; display:flex; flex-direction:column; gap:18px; align-items:center; color:#fdf9f4;}
-.start-overlay{height:100%; justify-content:flex-start; padding-top:12px;}
-#start-title{font-size:26px; line-height:1.35; text-shadow:0 4px 16px rgba(0,0,0,.35);}
-.start-cta{margin-top:auto;}
-
-/* 버튼 */
-.primary-btn,.secondary-btn{
-  font-family:'Shilla','Pretendard',-apple-system,BlinkMacSystemFont,sans-serif;
-  font-size:16px; border:none; border-radius:999px; padding:12px 28px; cursor:pointer;
-  transition:transform .15s, box-shadow .2s, background .2s;
-}
-.primary-btn{
-  font-family:'Shilla','Pretendard',-apple-system,BlinkMacSystemFont,sans-serif;
-  background:linear-gradient(135deg,#d8a662,#8f6330); 
-  color:#fffaf1; box-shadow:0 12px 24px rgba(59,33,7,.25);}
-.primary-btn:hover{transform:translateY(-2px); box-shadow:0 16px 32px rgba(59,33,7,.3);}
-.secondary-btn{background:rgba(176,124,58,.15); color:var(--accent-dark); border:1px solid rgba(176,124,58,.45);}
-.secondary-btn:hover{background:rgba(176,124,58,.25);}
-
-/* 스토리 화면 */
-#story-screen.screen.active {
-  justify-content: flex-start !important;
-  align-items: stretch;
-  text-align: left;
-  padding-top: 20px !important; /* 👈 스토리만 위로 붙임 */
-}
-/* ✅ 스토리 본문 여백도 조정 */
-#story-screen .story-wrapper {
-  margin-top: 0;
-  padding: 0 8px;
-}
-.story-text{
-  font-size:18px; line-height:1.65; min-height:140px;
-  color:var(--ink); margin-top:16px;
-  white-space:pre-line; /* ✅ 타자효과 줄바꿈 적용 */
-}
-.bottom-cta {
-  position: absolute;
-  bottom: 20px;
-  left: 50%;
-  transform: translateX(-50%);  /* ✅ 수평 중앙 정렬 */
-  text-align: center;
-  width: 100%;                  /* ✅ 모바일 360px 기준 폭 맞추기 */
+nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 12px 20px;
   display: flex;
-  justify-content: center;      /* ✅ 내부 버튼도 가운데 정렬 */
-  z-index: 2;
-}
-
-/* 성별 카드 */
-.gender-grid{
-  width:100%; display:grid; grid-template-columns:repeat(2,1fr);
-  gap:16px; margin-top:50px;
-}
-.gender-card{
-  font-family:'Shilla','Pretendard',-apple-system,BlinkMacSystemFont,sans-serif;
-  display: flex;
-  flex-direction: column;
   justify-content: flex-end;
+  gap: 12px;
+}
+
+nav a {
+  text-decoration: none;
+  color: var(--text-color);
+  font-weight: 500;
+  font-size: 14px;
+}
+
+.ad-container,
+.footer-ad-container {
+  width: 100%;
+  display: flex;
+  justify-content: center;
   align-items: center;
+  margin: 16px 0;
+}
+
+.run-lab {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  padding: 12px;
+}
+
+.app-shell {
+  width: 360px;
+  height: 550px;
+  background: #ffffff;
+  border-radius: 32px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  gap: 16px;
+}
+
+.control-panel {
+  background: var(--panel);
+  border-radius: 20px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel-head p:first-child {
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.panel-desc {
+  font-size: 13px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 8px;
-  height: 300px;              /* 👈 세로 고정 */
-  background-size: cover;     /* 👈 이미지 가득 채우기 */
-  background-position: center top;
-  background-repeat: no-repeat;
-  border-radius: 22px;
-  overflow: hidden;
 }
-.gender-label {
-  margin-bottom: 10px;
-  background: rgba(255,255,255,0.7);
+
+.panel-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.panel-field select,
+.panel-field input[type="color"] {
+  width: 100%;
+  border: 1px solid var(--border);
   border-radius: 12px;
-  padding: 4px 10px;
-  font-size:20px;
+  padding: 6px;
+  font-size: 13px;
+  font-family: inherit;
 }
 
-.gender-card:hover,.gender-card:focus{
-  transform:translateY(-4px);
-  border-color:rgba(176,124,58,.45);
-  background:rgba(255,255,255,.92);
+.panel-toggles {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
 }
-.gender-card.selected{ /* ✅ 선택 시 강조 */
-  border-color:var(--accent);
-  box-shadow:0 0 0 4px rgba(176,124,58,.25);
-}
-.gender-emoji{font-size:42px;}
-.gender-helper{font-size:16px; color:var(--muted); margin-top:12px;}
 
-#birth-screen{align-items:stretch;}
-#birth-screen h2{font-size:22px; margin-bottom:18px;}
-#birth-form{display:flex; flex-direction:column; gap:16px; width:100%;}
-.form-field{text-align:left; display:flex; flex-direction:column; gap:8px;}
-.form-field label{font-size:17px;}
-input[type="number"]{
-  border:1.5px solid rgba(176,124,58,.2); border-radius:16px; padding:12px 16px; font-size:17px;
-  background:rgba(255,255,255,.92); transition:border .2s, box-shadow .2s;
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #4b5563;
 }
-input[type="number"]:focus{outline:none; border-color:rgba(176,124,58,.55); box-shadow:0 0 0 3px rgba(176,124,58,.2);}
-.error-text{min-height:20px; font-size:15px; color:var(--error);}
 
-/* 로딩/결과 */
-.loading-wrapper,.result-wrapper{
-  display:flex; flex-direction:column; align-items:center; gap:18px; background:var(--surface);
-  padding:34px 26px; border-radius:24px;
-  box-shadow:inset 0 0 0 1px rgba(130,90,34,.08), 0 12px 28px rgba(44,32,20,.18);
+.record-card {
+  flex: 1;
+  background: linear-gradient(160deg, #ffffff 0%, var(--card-surface) 100%);
+  border-radius: 24px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
 }
-.loader{
-  width:64px; height:64px; border-radius:50%;
-  border:6px solid rgba(176,124,58,.25);
-  border-top-color:rgba(176,124,58,.85);
-  animation:spin 1.2s linear infinite;
+
+.record-card.glow {
+  box-shadow: 0 20px 45px rgba(255, 59, 88, 0.25), inset 0 0 0 1px rgba(255, 59, 88, 0.15);
 }
-@keyframes spin{to{transform:rotate(360deg);}}
-.loading-text{font-size:17px; color:var(--muted);}
 
-.result-name{font-size:32px; color:var(--accent-dark);}
-.result-desc{font-size:18px; color:var(--muted); line-height:1.5; white-space:pre-line;}
-
-/* 결과 하단 버튼들 */
-#bottom-actions{
-  position:absolute; left:16px; right:16px; bottom:16px;
-  display:flex; gap:10px; justify-content:center;
+.distance-section {
+  text-align: left;
 }
-#bottom-actions button{
-  font-family:'Shilla','Pretendard',-apple-system,BlinkMacSystemFont,sans-serif;
-  flex:1 1 auto; min-width:110px; text-align:center;
-  font-size:16px; padding:10px 16px; border:none; border-radius:12px; cursor:pointer;
-  box-shadow:0 8px 18px rgba(185,140,0,.12);
+
+.distance-display {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
 }
-#share-kakao{background:#fee500; color:#1c1207; font-weight:800;}
-#restart-btn{background:linear-gradient(180deg,#ffd9c7 0%, #ffc9b4 100%); color:#4a2d1f; font-weight:700;}
-#other-test-btn{background:#eee8de; color:#5a524d; font-weight:700;}
 
-.sr-only{position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;}
+.distance-number {
+  font-size: 64px;
+  font-weight: 700;
+  letter-spacing: -1px;
+  color: var(--text-color);
+}
 
-@media (max-width:480px){
-  nav{position:static;}
-  #app{margin-top:16px;}
+.unit {
+  font-size: 18px;
+  color: #9ca3af;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.metric {
+  border-radius: 18px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: rgba(248, 249, 255, 0.9);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.metric-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.metric-value {
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text-color);
+  min-height: 28px;
+}
+
+.metric input,
+.distance-section input {
+  width: 100%;
+  border: none;
+  border-radius: 12px;
+  padding: 8px 12px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #374151;
+  background: var(--input-surface);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
+.metric input:focus,
+.distance-section input:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent-color);
+}
+
+.action-row {
+  display: flex;
+  gap: 8px;
+}
+
+.primary-btn,
+.ghost-btn {
+  flex: 1;
+  border-radius: 999px;
+  border: none;
+  font-size: 15px;
+  font-weight: 600;
+  padding: 12px 16px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-btn {
+  background: var(--accent-color);
+  color: #ffffff;
+  box-shadow: 0 12px 20px rgba(255, 59, 88, 0.25);
+}
+
+.ghost-btn {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: #6b7280;
+}
+
+.primary-btn:active,
+.ghost-btn:active {
+  transform: translateY(1px);
+}
+
+.helper-text {
+  font-size: 12px;
+  color: #9ca3af;
+  text-align: center;
+}
+
+.coupang-slot {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin: 12px 0 32px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+/* Effect styles */
+.record-card[data-effect="bounce"] [data-display-group],
+.record-card[data-effect="bounce"] .metric-value {
+  animation: bounce 1.6s ease;
+}
+
+.record-card[data-effect="snap"] [data-display-group],
+.record-card[data-effect="snap"] .metric-value {
+  animation: snap 1s ease;
+}
+
+.record-card[data-effect="smooth"] [data-display-group],
+.record-card[data-effect="smooth"] .metric-value {
+  animation: smooth-rise 1.2s ease;
+}
+
+@keyframes bounce {
+  0% { transform: translateY(10px); opacity: 0; }
+  40% { transform: translateY(-12px); opacity: 1; }
+  70% { transform: translateY(4px); }
+  100% { transform: translateY(0); }
+}
+
+@keyframes snap {
+  0% { transform: scale(0.95); opacity: 0; }
+  60% { transform: scale(1.05); opacity: 1; }
+  100% { transform: scale(1); }
+}
+
+@keyframes smooth-rise {
+  0% { opacity: 0; transform: translateY(8px); }
+  100% { opacity: 1; transform: translateY(0); }
 }


### PR DESCRIPTION
## Summary
- remove the extra borders from the record card, stat tiles, and inputs so the tracker has a cleaner single-sheet look
- add a styled Coupang slot directly under the footer advertisement so the affiliate block now renders beneath the primary ad unit

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b25bedf308321ad55422f72af57b1)